### PR TITLE
選択範囲の移動の実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,13 @@ const App: React.FC = () => {
     set_canvas_tip_data(canvas_tip_data);
   }
 
+  // 範囲選択の際に用いる関数
+  // map_canvas側でid(マップチップの種類)を指定できる
+  const _handleCopyCanvasTip = (h:number, w:number, id:number) => {
+    canvas_tip_data[h][w] = id;
+    set_canvas_tip_data(canvas_tip_data);
+  }
+
   // キャンバスサイズの変更
   // 入力したサイズを現在のサイズと比較して小さい方を基準にcanvas_tip_dataを再設定する
   const _set_canvas_size = (input_size: number[]) => {
@@ -110,6 +117,7 @@ const App: React.FC = () => {
               propGetCanvasWidth={handleGetCanvasWidth}
               propGetMapTip={handleGetMapTip} 
               propClickCanvasTip={_handleClickCanvasTip}
+              propCopyCanvasTip={_handleCopyCanvasTip}
               />
 
           </Col>

--- a/src/components/map_canvas.tsx
+++ b/src/components/map_canvas.tsx
@@ -20,7 +20,7 @@ let ratio: number = 1; // 拡大縮小比率
 let i: number, j: number; // for文用
 let isDrawing: boolean = false; // マウスが左クリックされているかどうか
 let isSelecting: boolean = false; // マウスが右クリックされているかどうか
-//let isMoving: boolean = false; // 選択した範囲を動かしているか
+let isMoving: boolean = false; // 選択した範囲を動かしているか
 let x: number = 0; // マウスのx座標の処理に使う
 let y: number = 0; // マウスのy座標の処理に使う
 let startSelect: number[] = [0, 0]; // 右クリックを押した座標
@@ -29,8 +29,9 @@ let img = new Image(); // マップチップを保存
 //img.src = `${process.env.PUBLIC_URL}/maptip/maptip3.png`; // マップチップ仮指定
 let now_maptip_edge_size: number = maptip_edge_size*ratio;
 let now_canvas_size: number[] = [60, 100];
-let selectArea: number[]; // 選択範囲の左上と右下の座標
-//let selectAreaTips: number[]; // 範囲選択した部分のマップチップデータ
+let selectArea: number[] = [0, 0, 0, 0]; // 選択範囲の左上と右下の座標
+let areaMove:number[] = [0, 0]; // 選択範囲の移動距離
+let startMove:number[] = [0, 0]; // 選択範囲内のどこを押したか
 
 type MapCanvasProps = {
   //maptip_id: number
@@ -38,6 +39,7 @@ type MapCanvasProps = {
   propGetCanvasWidth: () => number;
   propGetMapTip: (h: number, w: number) => number;
   propClickCanvasTip: (h: number, w: number) => void;
+  propCopyCanvasTip: (h: number, w: number, id:number) => void;
 };
 
 const Map_Canvas: React.FC<MapCanvasProps> = ({
@@ -46,25 +48,40 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
   propGetCanvasWidth,  
   propGetMapTip,
   propClickCanvasTip,
+  propCopyCanvasTip
 }) => {
-  const [ temp_state, set_temp_state] = useState<number>(0);
-  const [update,setUpdata]=useState<boolean>(false)
+  const [temp_state, set_temp_state] = useState<number>(0);
+  const [update,　setUpdata]　=　useState<boolean>(false);
   const canvasRef = useRef(null); // nullで初期化しているのでcurrentプロパティは書き換えられない
   const effectRef = useRef(null);
-  console.log(temp_state);
+  const moveRef = useRef(null);
+  console.log(temp_state); // 使いどころがないのでエラー回避のためにここで使っておく
+  console.log(update); // 〃
 
   // CanvasオブジェクトのgetContext()は、キャンパスに描画するためのコンテキスト(CanvasRenderingContext2Dオブジェクトなど)を取得するメソッド
   // 引数にコンテキストの種類を指定する　二次元グラフィックを描画するための2d、三次元グラフィックスを描画するためのwebglが主な引数
-  const getContext = (): CanvasRenderingContext2D => {
+  const getContext = (): CanvasRenderingContext2D => { // メインのCanvas
     const canvas: any = canvasRef.current;
     return canvas.getContext('2d');
   };
 
-  const getEffectContext = (): CanvasRenderingContext2D => {
+  const getEffectContext = (): CanvasRenderingContext2D => { // 選択範囲の描画用Canvas
     const canvas: any = effectRef.current;
     return canvas.getContext('2d');
   };
 
+  const getMoveContext = (): CanvasRenderingContext2D => { // 選択範囲の移動先描画用Canvas
+    const canvas: any = moveRef.current;
+    return canvas.getContext('2d');
+  };
+
+  // 2次元配列の生成に用いる
+  // なんかこういう風に宣言しないとアドレスがバグる
+  const generate2DArray = (m:number, n:number) => {
+    return Array.from(new Array(m), _ => new Array(n).fill(-1));
+  };
+
+  // キャンバスサイズの変更
   const resizeCanvas = () => {
     const canvas: any = canvasRef.current;
     const effect_canvas: any = effectRef.current;
@@ -75,51 +92,91 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
     console.log("resize")
   };
 
-  // マウスを押したとき描画フラグをtrue
+  // マウスのボタンを押したときに呼ばれる関数
   function handleOnMouseDown(e:any) {
-    if(e.nativeEvent.which === 1) {
+    if(e.nativeEvent.which === 1) { // マウスの左クリックをしたとき
       isDrawing = true;
-    } else if(e.nativeEvent.which === 3) {
-      isSelecting = true;
+    } else if(e.nativeEvent.which === 3) { // マウスの右クリックをしたとき
       startSelect = matchGrid(e);
-    } else if(e.nativeEvent.which === 2 && isSelecting) {
+      if(inSelectArea()) { // 右クリックした場所が選択範囲内だった時
+        isMoving = true;
+        console.log("isMoveing")
+      } else {
+        isSelecting = true;
+        console.log("isSelecting")
+      }
+    } else if(e.nativeEvent.which === 2 && isSelecting) { // 範囲選択をしている状態でマウスの中央クリックをしたとき
       e.preventDefault();
       fillArea(e);
     }
     handleMouseMove(e);
   }
 
-  // マウスを離したとき描画フラグをfalse
+  // 選択範囲内をクリックしたかどうかのチェック
+  const inSelectArea = (): boolean => {
+    if(Math.floor(startSelect[0]/now_maptip_edge_size) >= selectArea[0] && Math.floor(startSelect[0]/now_maptip_edge_size) <= selectArea[0]+selectArea[2]) {
+      if(Math.floor(startSelect[1]/now_maptip_edge_size) >= selectArea[1] && Math.floor(startSelect[1]/now_maptip_edge_size) <= selectArea[1]+selectArea[3]) {
+        console.log("inSelectingArea")
+        startMove = [Math.floor(startSelect[0]/now_maptip_edge_size), Math.floor(startSelect[1]/now_maptip_edge_size)]
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // マウスのボタンを離したときに呼ばれる関数
   function handleOnMouseUp(e:any) {
-    if(e.nativeEvent.which === 1) {
+    if(e.nativeEvent.which === 1) { // マウス右ボタンを離したとき描画フラグをfalse
       isDrawing = false;
     } else if(e.nativeEvent.which === 3) {
-      endSelect = matchGrid(e);
-      const ectx: CanvasRenderingContext2D = getEffectContext(); 
-      ectx.clearRect(0, 0, propGetCanvasWidth()*maptip_edge_size, propGetCanvasHeight()*maptip_edge_size);
-      if(startSelect[0] == endSelect[0] && startSelect[1] == endSelect[1]) { // 1マス選択は無理
-        isSelecting = false;
-        console.log("endSelecting");
-      } else {
-        selectArea= effectGrid(startSelect, endSelect);
-        //ectx.beginPath();
-        ectx.strokeStyle = 'red';
-        ectx.fillStyle = "rgba(" + [200, 0, 0, 0.1] + ")";
-        ectx.strokeRect(selectArea[0]*now_maptip_edge_size, selectArea[1]*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
-        ectx.fillRect(selectArea[0]*now_maptip_edge_size, selectArea[1]*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
+      const ectx: CanvasRenderingContext2D = getEffectContext();
+      const mctx: CanvasRenderingContext2D = getMoveContext();
+      mctx.clearRect(0, 0, propGetCanvasWidth()*maptip_edge_size, propGetCanvasHeight()*maptip_edge_size);
+      if(isMoving === false) { // 選択範囲の移動中でない場合
+        ectx.clearRect(0, 0, propGetCanvasWidth()*maptip_edge_size, propGetCanvasHeight()*maptip_edge_size);
+        endSelect = matchGrid(e);
+        if(startSelect[0] == endSelect[0] && startSelect[1] == endSelect[1]) { // 1マス選択は無理
+          isSelecting = false;
+          selectArea = [0, 0, 0, 0]; // selectAreaを初期化
+        } else { // 選択した範囲を取得し、その範囲を表示する
+          selectArea = effectGrid(startSelect, endSelect);
+          ectx.strokeStyle = 'red';
+          ectx.fillStyle = "rgba(" + [200, 0, 0, 0.1] + ")";
+          ectx.strokeRect(selectArea[0]*now_maptip_edge_size, selectArea[1]*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
+          ectx.fillRect(selectArea[0]*now_maptip_edge_size, selectArea[1]*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
+        }
+      } else if(isMoving === true){ // 選択範囲の移動中
+        if(areaMove[0] != 0 || areaMove[1] != 0) { // 移動距離が0でないときのみ移動を行う
+          ectx.clearRect(0, 0, propGetCanvasWidth()*maptip_edge_size, propGetCanvasHeight()*maptip_edge_size);
+          let selectAreaTips: number[][] = generate2DArray(selectArea[2], selectArea[3]); // 範囲選択した部分のマップチップデータ
+          for(i = 0; i < selectArea[2]; i++) {
+            for(j = 0; j < selectArea[3]; j++) {
+              selectAreaTips[i][j] = propGetMapTip(Math.floor(selectArea[1]+j), Math.floor(selectArea[0]+i));
+              propCopyCanvasTip(selectArea[1]+j, selectArea[0]+i, -1);
+            }
+          }
+          selectArea[0] += areaMove[0];
+          selectArea[1] += areaMove[1];
+          for(i = 0; i < selectArea[2]; i++) {
+            for(j = 0; j < selectArea[3]; j++) {
+              propCopyCanvasTip(selectArea[1]+j, selectArea[0]+i, selectAreaTips[i][j]);
+            }
+          }
+          ectx.strokeStyle = 'red';
+          ectx.fillStyle = "rgba(" + [200, 0, 0, 0.1] + ")";
+          ectx.strokeRect(selectArea[0]*now_maptip_edge_size, selectArea[1]*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
+          ectx.fillRect(selectArea[0]*now_maptip_edge_size, selectArea[1]*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
+          setUpdata(prestate => !prestate);
+        }
+        isMoving = false;
+        areaMove = [0, 0];
       }
+      
     }
   }
 
-  {/**
-    選択範囲のマップチップデータををコピー
-    移動先に貼り付けると同時に元のところのデータを消し、選択範囲も移動する
-    端に移動した場合は例外処理を行う
-    copyArea, pasteArea
-
-  */}
-
-  // 選択範囲を[始点のx座標，始点のy座標，x方向の選択距離，y方向の選択距離]の形で出来た
+  // 選択範囲を[始点のx座標，始点のy座標，x方向の選択距離，y方向の選択距離]の形で取得
+  // 単位はマス目なのでpxで使いたい場合は *now_maptip_edge_size をする必要がある
   const effectGrid = (s:number[], e:number[]) => {
     const selectingArea: number[] = [Math.floor(Math.min(s[0], e[0])/now_maptip_edge_size), Math.floor(Math.min(s[1], e[1])/now_maptip_edge_size), Math.floor(Math.abs(s[0]-e[0])/now_maptip_edge_size + 1), Math.floor(Math.abs(s[1]-e[1])/now_maptip_edge_size + 1)]; 
     console.log(selectingArea);
@@ -127,6 +184,7 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
   }
 
   // startSelectとendSelectをセットするときに使う
+  // 単位はpxなのでマス目で使いたい場合は /now_maptip_edge_size をする必要がある
   const matchGrid = (e:any) => {
     let rect: any = e.target.getBoundingClientRect();
     // マス目に合わせる処理
@@ -135,15 +193,14 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
     let tmp:number;
     tmp = x % now_maptip_edge_size;
     x -= tmp;
-    //x = Math.floor(x / now_maptip_edge_size);
     tmp = y % now_maptip_edge_size;
     y -= tmp;
-    //y = Math.floor(y / now_maptip_edge_size);
     return [x, y]
   }
 
+　// マウスの移動中に呼び出される関数
   function handleMouseMove(e:any) {
-    if(isDrawing) {
+    if(isDrawing) { // 描画中（左クリック中）
       let rect: any = e.target.getBoundingClientRect();
       // マス目に合わせる処理
       x = e.clientX - rect.left;
@@ -156,6 +213,27 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
       propClickCanvasTip(Math.floor(y/now_maptip_edge_size), Math.floor(x/now_maptip_edge_size));
       console.log(propGetMapTip(Math.floor(y/now_maptip_edge_size), Math.floor(x/now_maptip_edge_size)))
       drawMapTip(x, y);
+    } else if(isMoving) { // 選択範囲の移動中（右クリック中）
+      const mctx: CanvasRenderingContext2D = getMoveContext();
+      mctx.clearRect(0, 0, propGetCanvasWidth()*maptip_edge_size, propGetCanvasHeight()*maptip_edge_size);
+    　// マス目に合わせる処理
+      let rect: any = e.target.getBoundingClientRect();
+      x = e.clientX - rect.left;
+      y = e.clientY - rect.top;
+      let tmp:number;
+      tmp = x % now_maptip_edge_size;
+      x -= tmp;
+      tmp = y % now_maptip_edge_size;
+      y -= tmp;
+      // 移動先がCanvas外に行かないように(範囲外を参照しないように)する処理
+      if(selectArea[0]+Math.floor(x/now_maptip_edge_size)-startMove[0]>=0 && selectArea[1]+Math.floor(y/now_maptip_edge_size)-startMove[1]>=0) {
+        if(selectArea[0]+selectArea[2]+Math.floor(x/now_maptip_edge_size)-startMove[0]<=propGetCanvasWidth() && selectArea[1]+selectArea[3]+Math.floor(y/now_maptip_edge_size)-startMove[1]<=propGetCanvasHeight())
+        areaMove = [Math.floor(x/now_maptip_edge_size)-startMove[0], Math.floor(y/now_maptip_edge_size)-startMove[1]];
+      }
+      mctx.strokeStyle = 'blue';
+      mctx.fillStyle = "rgba(" + [0, 0, 200, 0.1] + ")";
+      mctx.strokeRect((areaMove[0]+selectArea[0])*now_maptip_edge_size, (areaMove[1]+selectArea[1])*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
+      mctx.fillRect((areaMove[0]+selectArea[0])*now_maptip_edge_size, (areaMove[1]+selectArea[1])*now_maptip_edge_size, selectArea[2]*now_maptip_edge_size, selectArea[3]*now_maptip_edge_size);
     }
   }
 
@@ -163,12 +241,11 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
   function drawMapTip(cx:number, cy:number) {
     const ctx: CanvasRenderingContext2D = getContext();
     if (propGetMapTip(Math.floor(cy/now_maptip_edge_size), Math.floor(cx/now_maptip_edge_size)) == -1) {
-      ctx.clearRect(cx, cy, now_maptip_edge_size, now_maptip_edge_size);//プログラム更新時に一旦全体をクリアする
+      ctx.clearRect(cx, cy, now_maptip_edge_size, now_maptip_edge_size);
       ctx.beginPath();
       ctx.strokeStyle = 'black';
       ctx.strokeRect(cx, cy, now_maptip_edge_size, now_maptip_edge_size);
-    }
-    else{
+    } else {
       img.src = `${process.env.PUBLIC_URL}/maptip/maptip${propGetMapTip(Math.floor(y/ now_maptip_edge_size), Math.floor(x/ now_maptip_edge_size)) + 1}.png`
       ctx.drawImage(img, cx, cy, now_maptip_edge_size, now_maptip_edge_size);
       console.log(cx, cy, now_maptip_edge_size, now_maptip_edge_size)
@@ -178,13 +255,14 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
 
   // 拡大縮小用キー入力受け取り
   // キャンバス部分を選択していなくてもキー入力だけで動作するため他の機能で使わなさそうなキーを使う
+  // ちなみにここでuseStateを変更しようとすると何故かできない
   const enterFunction = useCallback((event) => {
-    if(event.keyCode === 191 && ratio < 2) {
+    if(event.keyCode === 191 && ratio < 2) { // "/"を押したとき拡大　1次関数の傾きが正のイメージ
       ratio += 0.1;
       now_maptip_edge_size = maptip_edge_size*ratio;
       resizeCanvas();
       set_temp_state(ratio);
-    } else if(event.keyCode === 226 && ratio > 0.41) {
+    } else if(event.keyCode === 226 && ratio > 0.41) { // "\"を押したとき縮小　1次関数の傾きが部のイメージ
       ratio -= 0.1;
       now_maptip_edge_size = maptip_edge_size*ratio;
       resizeCanvas();
@@ -192,17 +270,14 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
     }
   }, []);
 
-    function fillArea(e: any) {
-    //const ctx: CanvasRenderingContext2D = getContext(); // 二次元グラフィックスのコンテキストを取得
-    // x 方向に描画する
+  // 塗りつぶしを行う関数
+  function fillArea(e: any) {
     for (i = selectArea[0]; i < selectArea[0]+selectArea[2]; i++) {
-      // y 方向に描画する
       for (j = selectArea[1]; j < selectArea[1]+selectArea[3]; j++) {
         propClickCanvasTip(j,i);
       }
     }
-    setUpdata(prestate => !prestate);
-    console.log(update)
+    setUpdata(prestate => !prestate); // useEffectを強制的に呼び出す
   }
 
   // 右クリックでメニューが開かないようにする
@@ -213,6 +288,7 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
 
   // useEffect: 副作用を有する可能性のある命令型のコードを受け付ける
   // 副作用をReactのrenderフェーズで行うとバグとか非整合が起こるのでこれ使う
+  // 呼ばれるタイミングはuseStateが変更された時、宣言されたときなど
   useEffect(() => {
     isSelecting =  isSelecting;
     now_canvas_size[0] = propGetCanvasHeight();
@@ -272,6 +348,17 @@ const Map_Canvas: React.FC<MapCanvasProps> = ({
       width={propGetCanvasWidth()*maptip_edge_size*ratio}
       height={propGetCanvasHeight()*maptip_edge_size*ratio}
       ref={effectRef}
+      onMouseDown={handleOnMouseDown} //マウスが押されたとき
+      onMouseMove={handleMouseMove}   //マウスが動いているとき
+      onMouseUp={handleOnMouseUp}     //マウスを離したとき
+      onMouseOut={handleOnMouseUp}    //マウスがキャンバスの外に出た時
+    />
+    <canvas
+      id = "mapCanvas"
+      className="MapCanvas"
+      width={propGetCanvasWidth()*maptip_edge_size*ratio}
+      height={propGetCanvasHeight()*maptip_edge_size*ratio}
+      ref={moveRef}
       onMouseDown={handleOnMouseDown} //マウスが押されたとき
       onMouseMove={handleMouseMove}   //マウスが動いているとき
       onMouseUp={handleOnMouseUp}     //マウスを離したとき


### PR DESCRIPTION
範囲選択関連はこれで完成
右クリックしたドラッグで範囲を選択
選択範囲が1マスの場合選択解除
選択範囲内を右クリックしてドラッグすると移動させられる
選択範囲内を中央クリックすると塗りつぶせる
